### PR TITLE
Move concept classes from core-db to core-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: groovy
+
+jdk:
+    - oraclejdk7
+
+notifications:
+  hipchat:
+    rooms:
+      secure: cebpY+7DHTX9Djq1rxVSjnh7BuLKpijEVWK71LOq7jPXtfgNKpdsQZslXvzR/r5+AKQ9IvoM02oBQEvXyJMYKskknnxRxiG6hkDm4Xuz9O+2wO0/qpbbC3qgVmEjSH/opmi9FW4UTtlCGZv0g3OmMsRJ51U7eDIrqEfuiX7hUrs=

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,23 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -96,5 +113,7 @@
         <groovyVersion>2.1.0</groovyVersion>
         <gmavenProviderSelection>2.0</gmavenProviderSelection>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <guava.version>14.0.1</guava.version>
+        <hamcrest.version>1.3</hamcrest.version>
     </properties>
 </project>

--- a/src/main/groovy/org/transmartproject/core/concept/ConceptFullName.groovy
+++ b/src/main/groovy/org/transmartproject/core/concept/ConceptFullName.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2013-2014 The Hyve B.V.
+ *
+ * This file is part of transmart-core-db.
+ *
+ * Transmart-core-db is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-core-db.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transmartproject.core.concept
+
+import com.google.common.base.Splitter
+import com.google.common.collect.Lists
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * Represents an i2b2 concept full name.
+ */
+@EqualsAndHashCode
+final class ConceptFullName {
+    private final String fullPath
+    final List<String> parts
+
+    ConceptFullName(String path) {
+        if (path.size() == 0 || path[0] != '\\')
+            throw new IllegalArgumentException('Path should start with \\')
+        if (path.size() < 2)
+            throw new IllegalArgumentException('Path is too short')
+        if (path[-1] != '\\')
+            path += '\\'
+
+        this.fullPath = path
+
+        // trim the first leading and trailing backslash for split
+        path = path.replaceFirst('^\\\\', '').replaceFirst('\\\\$', '')
+        parts = Lists.newArrayList(Splitter.on('\\').split(path))
+
+        if (parts.size() == 0 || '' in parts) {
+            throw new IllegalArgumentException(
+                    "Path cannot have empty parts (got '$path')")
+        }
+    }
+
+    def getAt(int index) {
+        if (index < 0)
+            index = parts.size() + index
+
+        index < parts.size() ? parts[index] : null
+    }
+
+    def getAt(Range range) {
+        parts[range]
+    }
+
+    def getLength() {
+        parts.size()
+    }
+
+    ConceptFullName getParent() {
+        if (length == 1) {
+            return null
+        }
+        new ConceptFullName('\\' + parts[0..-2].join('\\') + '\\')
+    }
+
+    boolean isSiblingOf(ConceptFullName otherFullName) {
+        otherFullName.length == this.length &&
+                this.length == 1 ||
+                otherFullName.parts[1..-1] == this.parts[1..-1]
+    }
+
+    @Override
+    public String toString() {
+        fullPath
+    }
+}

--- a/src/main/groovy/org/transmartproject/core/concept/ConceptKey.groovy
+++ b/src/main/groovy/org/transmartproject/core/concept/ConceptKey.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2013-2014 The Hyve B.V.
+ *
+ * This file is part of transmart-core-db.
+ *
+ * Transmart-core-db is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-core-db.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transmartproject.core.concept
+
+import groovy.transform.EqualsAndHashCode
+
+/*
+ * A concept key is made of two parts: \\c_table_cd\c_fullname
+ *
+ * The c_table_cd describes the metadata table wherein the concept is stored,
+ * while c_fullname is a unique identifier for the concept itself.
+ */
+@EqualsAndHashCode
+class ConceptKey {
+
+    final String tableCode
+    final ConceptFullName conceptFullName
+
+    ConceptKey(String key) {
+        if (key == null)
+            throw new IllegalArgumentException('Concept key is null')
+        if (key.size() < 5 /* \\a\b */)
+            throw new IllegalArgumentException("Concept key is too short")
+        if (key[0..1] != '\\\\')
+            throw new IllegalArgumentException('Concept key must start with ' +
+                    '\\\\')
+
+        def matcher = (key =~ '\\\\')
+        if (!matcher.find(3))
+            throw new IllegalArgumentException('No \\ character found after ' +
+                    'position 2')
+
+        tableCode = key.substring(2, matcher.start())
+        conceptFullName = new ConceptFullName(key.substring(matcher.start()))
+    }
+
+    ConceptKey(String tableCode, String fullName) {
+        if (tableCode == null || fullName == null)
+            throw new IllegalArgumentException('Table code or full name are ' +
+                    'null')
+        if (tableCode.find('\\\\') != null)
+            throw new IllegalArgumentException("Table code includes a " +
+                    "back slash")
+        this.tableCode = tableCode
+        conceptFullName = new ConceptFullName(fullName)
+    }
+
+    @Override
+    public String toString() {
+        return "\\\\" + tableCode + conceptFullName
+    }
+}

--- a/src/main/groovy/org/transmartproject/core/ontology/OntologyTermTag.groovy
+++ b/src/main/groovy/org/transmartproject/core/ontology/OntologyTermTag.groovy
@@ -1,0 +1,19 @@
+package org.transmartproject.core.ontology
+
+/**
+ * Key-value pair entry.
+ * Tags hold additional statements about ontology term.
+ */
+interface OntologyTermTag {
+
+    /**
+     * @return Tag label name. It should be unique per ontology term.
+     */
+    String getName()
+
+    /**
+     * @return Free text value.
+     */
+    String getDescription()
+
+}

--- a/src/main/groovy/org/transmartproject/core/ontology/OntologyTermTagsResource.groovy
+++ b/src/main/groovy/org/transmartproject/core/ontology/OntologyTermTagsResource.groovy
@@ -1,0 +1,16 @@
+package org.transmartproject.core.ontology
+
+/**
+ * Resource for ontology term tags retrieval.
+ */
+interface OntologyTermTagsResource {
+
+    /**
+     * Retrieve tags by related terms
+     * @param ontologyTerms term for which to retrieve tags for
+     * @param includeDescendantsTags whether to include tags that are related with descendant terms
+     * @return Multi-map of tags. The order of the tags is fixed.
+     */
+    Map<OntologyTerm, List<OntologyTermTag>> getTags(Set<OntologyTerm> ontologyTerms, boolean includeDescendantsTags)
+
+}

--- a/src/test/groovy/org/transmartproject/core/concept/ConceptFullNameTests.groovy
+++ b/src/test/groovy/org/transmartproject/core/concept/ConceptFullNameTests.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2013-2014 The Hyve B.V.
+ *
+ * This file is part of transmart-core-api.
+ *
+ * Transmart-core-api is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-core-api.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transmartproject.core.concept
+
+import org.junit.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.Assert.fail
+import static org.hamcrest.Matchers.*
+
+class ConceptFullNameTests {
+
+    @Test
+    void basicTest() {
+        def conceptFullName = new ConceptFullName('\\abc\\d\\e')
+
+        assertThat conceptFullName, hasProperty('length', equalTo(3))
+        assert conceptFullName[0] == 'abc'
+        assert conceptFullName[1] == 'd'
+        assert conceptFullName[2] == 'e'
+        assert conceptFullName[3] == null
+        assert conceptFullName[-2] == 'd'
+    }
+
+    @Test
+    void trailingSlashIsOptional() {
+        def c1 = new ConceptFullName('\\a'),
+            c2 = new ConceptFullName('\\a\\')
+
+        assertThat c1, is(equalTo(c2))
+    }
+
+    @Test
+    void testBadPaths() {
+        def paths = ['', '\\', '\\\\', '\\a\\\\', '\\a\\\\b']
+
+        paths.each({
+            try {
+                def c = new ConceptFullName(it)
+                fail "Could create ConceptFullName with path " + it + ", " +
+                        "result: " + c
+            } catch (Exception iae) {
+                assertThat iae, isA(IllegalArgumentException)
+            }
+        })
+    }
+}

--- a/src/test/groovy/org/transmartproject/core/concept/ConceptKeyTests.groovy
+++ b/src/test/groovy/org/transmartproject/core/concept/ConceptKeyTests.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2013-2014 The Hyve B.V.
+ *
+ * This file is part of transmart-core-api.
+ *
+ * Transmart-core-api is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-core-api.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transmartproject.core.concept
+
+import org.junit.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.Assert.fail
+import static org.hamcrest.Matchers.*
+
+class ConceptKeyTests {
+
+    @Test
+    void basicTest() {
+        def conceptKey = new ConceptKey('\\\\tableCode\\full\\thing\\')
+
+        assertThat conceptKey, allOf(
+                hasProperty('tableCode', equalTo('tableCode')),
+                hasProperty('conceptFullName', hasProperty('length',
+                        equalTo(2))))
+    }
+
+    @Test
+    void basicTestAlternativeConstructor() {
+        def conceptKey = new ConceptKey('tableCode', '\\full\\thing\\')
+
+        assert conceptKey == new ConceptKey('\\\\tableCode\\full\\thing\\')
+    }
+
+    @Test
+    void badInput() {
+        def keys = ['', '\\\\', '\\\\\\', '\\\\a\\', '\\as\\b',
+                '\\\\a\\b\\\\', null]
+
+        keys.each({
+            try {
+                new ConceptKey(it)
+                fail "Could create ConceptKey with value " + it
+            } catch (Exception iae) {
+                assertThat iae, isA(IllegalArgumentException)
+            }
+        })
+    }
+
+}


### PR DESCRIPTION
Concept classes have been moved from core-db to core-api. This PR should be merged together with the [PR on transmart-core-db](https://github.com/PMtranSMART/transmart-core-db/pull/18).